### PR TITLE
Fixed a bug in processActionOptions

### DIFF
--- a/lib/players.js
+++ b/lib/players.js
@@ -133,7 +133,7 @@ Player.prototype.getAvailableActions = function(clone) {
       };
     }
 
-    processActionOptions(output[action], this.room);
+    processActionOptions(output[action], this.room, this);
   }
 
   return output;
@@ -179,7 +179,7 @@ function setAttributeObject(p, attr, name, value) {
   }
 }
 
-function processActionOptions(action, room) {
+function processActionOptions(action, room, player) {
 
   switch(action.type) {
 
@@ -200,7 +200,7 @@ function processActionOptions(action, room) {
       } else if(Array.isArray(action.options.choices)) {
         action.options.safeChoices = action.options.choices;
       } else {
-        action.options.safeChoices = action.options.choices(room, this);
+        action.options.safeChoices = action.options.choices(room, player);
       }
 
       break;


### PR DESCRIPTION
Je me suis cassé la tête une bonne partie de la nuit pour trouver pourquoi dans mafia/libs/actions.js l'objet `player` passé à la fonction `choices(room, player)` n'était pas valide... Impossible de récupérer le joueur appelant la fonction au chargement de son propre pouvoir !

Finalement voilà le bug... Dans openparty/libs/players.js la fonction `processActionOptions` est déclarée en dehors de la classe `Player` donc ne peut pas passer `this` en appelant `action.options.choices(room, player)`

J'ai juste rajouté un paramètre pour passer l'objet à `processActionOptions` et ça marche enfin :')