### PR TITLE
Set timer to real time lapse

### DIFF
--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -38,7 +38,9 @@ controller('controller', ['$scope', 'socket', '$interval', 'ngAudio', function (
   // Timer
 
   $scope.timer         = null;
-  $scope.remainingTime = {raw: 0, min: '--', sec: '--'};
+  $scope.timerStart    = null;
+  $scope.timerDuration = null;
+  $scope.remainingTime = {min: '--', sec: '--'};
 
   // Actions
 
@@ -336,7 +338,8 @@ controller('controller', ['$scope', 'socket', '$interval', 'ngAudio', function (
 
   socket.on('setTimer', function(data) {
     $interval.cancel($scope.timer);
-    $scope.remainingTime.raw = +data;
+    $scope.timerDuration = data;
+    $scope.timerStart = new Date().getTime();
     $scope.timer = $interval($scope.writeTimer, 1000);
     $scope.writeTimer();
   });
@@ -400,7 +403,8 @@ controller('controller', ['$scope', 'socket', '$interval', 'ngAudio', function (
 
   $scope.writeTimer = function() {
 
-    var time = $scope.remainingTime.raw--;
+    var now = new Date().getTime();
+    var time = Math.trunc($scope.timerDuration - (now - $scope.timerStart) / 1000);
 
     if(time <= 0) {
       $scope.remainingTime.min = '--';

--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -338,7 +338,7 @@ controller('controller', ['$scope', 'socket', '$interval', 'ngAudio', function (
 
   socket.on('setTimer', function(data) {
     $interval.cancel($scope.timer);
-    $scope.timerDuration = data;
+    $scope.timerDuration = +data;
     $scope.timerStart = new Date().getTime();
     $scope.timer = $interval($scope.writeTimer, 1000);
     $scope.writeTimer();


### PR DESCRIPTION
Hello comme on avait dit j'ai passé les timers en évaluation du "temps réel" écoulé.

C'est beaucoup mieux pour les onglets masqués !

Pour être honnête, avec plusieurs tab sur la même partie on peut voir encore une différence d'une seconde (ou un peu plus) entre les timers..

Je pense que c'est du au fait qu'un tab masqué réagit plus lentement au broadcast. Il démarre son timer un peu plus tard que le tab qui a le focus.

En tout cas ça ne dépasse pas 1-2 secondes au pire des cas, ça ne devrait plus trop déranger pour les votes.

Le plus important c'est qu'un tab qui a le focus et démarre son timer correctement, gardera un affichage synchronisé même si on le masque après.

Voilà voilà :)